### PR TITLE
feat: add /tools command to CLI

### DIFF
--- a/ronnyx/cli.py
+++ b/ronnyx/cli.py
@@ -20,7 +20,7 @@ BANNER = r"""
 def chat_loop(base_url: str, session_id: str) -> None:
     print(BANNER)
     print(f"Connected to {base_url} (session: {session_id})")
-    print("Type 'exit' or 'quit' to leave.\n")
+    print("Type 'exit' or 'quit' to leave. Use '/tools' to list available tools.\n")
 
     while True:
         try:
@@ -34,6 +34,23 @@ def chat_loop(base_url: str, session_id: str) -> None:
 
         if message.lower() in {"exit", "quit"}:
             break
+
+        if message.lower() == "/tools":
+            tools_url = base_url.replace("/api/chat", "/api/tools")
+            try:
+                response = requests.get(tools_url, timeout=30)
+                response.raise_for_status()
+                tools = response.json()
+                if tools:
+                    print("Available tools:")
+                    for tool in tools:
+                        name = tool if isinstance(tool, str) else tool.get("name", str(tool))
+                        print(f" - {name}")
+                else:
+                    print("No tools loaded.")
+            except requests.RequestException as exc:
+                print(f"[error] request failed: {exc}")
+            continue
 
         try:
             response = requests.post(


### PR DESCRIPTION
## Summary

- Adds `/tools` command to the REPL chat loop in `ronnyx/cli.py`
- Derives the tools endpoint by replacing `/api/chat` with `/api/tools` in the base URL
- Displays loaded tool names as a formatted list; handles both string and object responses
- Updates the startup hint message to mention the new command

Closes #8